### PR TITLE
Remove permissionOverwrites

### DIFF
--- a/events/voiceChannelJoin.js
+++ b/events/voiceChannelJoin.js
@@ -11,12 +11,7 @@ module.exports = async (client, log, member, channel) => {
       const newOptions = {
         name: `${dynamicChannelPrefix} ${member.nickname}`,
         parent: channel.parentID,
-        type: 'voice',
-        permissionOverwrites: [{
-          id: member.id,
-          allow: ['MANAGE_CHANNELS'],
-          type: 'member'
-        }]
+        type: 'voice'
       };
       newChannel = await channel.clone(newOptions);
       client.dynamicChannels.set(newChannel.id, { authorId: member.id, voiceChannel: newChannel });


### PR DESCRIPTION
Removing the permissions overwrite would be a good step in order to prevent users from abusing the dynamic channels feature.