### PR TITLE
Prevent GH Actions to show logs by detaching docker-compose logs

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,4 +17,4 @@ jobs:
           script: |
             cd ${{secrets.APP_PATH}}
             git pull origin master
-            ENVIRONMENT=production DATABASE_PORT=5432 docker-compose up --build
+            ENVIRONMENT=production DATABASE_PORT=5432 docker-compose up --build -d


### PR DESCRIPTION
It is needed to keep our Actions minutes safe